### PR TITLE
Added support for DisplayName data annotation

### DIFF
--- a/Mvc.JQuery.Datatables.Example/App_Start/RegisterDatatablesModelBinder.cs
+++ b/Mvc.JQuery.Datatables.Example/App_Start/RegisterDatatablesModelBinder.cs
@@ -7,7 +7,7 @@ using System.Web.WebPages;
 namespace Mvc.JQuery.Datatables.Example.App_Start {
     public static class RegisterDatatablesModelBinder {
         public static void Start() {
-            ModelBinders.Binders.Add(typeof(Mvc.JQuery.Datatables.DataTablesParam), new Mvc.JQuery.Datatables.DataTablesModelBinder());
+            ModelBinders.Binders.Add(typeof(DataTablesParam), new DataTablesModelBinder());
         }
     }
 }

--- a/Mvc.JQuery.Datatables.Example/Controllers/HomeController.cs
+++ b/Mvc.JQuery.Datatables.Example/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Web;
@@ -39,6 +40,7 @@ namespace Mvc.JQuery.Datatables.Example.Controllers
                 Hired = user.Hired
             });
         }
+
         public DataTablesResult GetUsersUntyped(DataTablesParam dataTableParam)
         {
             var users = Users();
@@ -79,6 +81,7 @@ namespace Mvc.JQuery.Datatables.Example.Controllers
     public class User
     {
         public int Id { get; set; }
+        
         public string Name { get; set; }
         public string Email { get; set; }
 
@@ -92,6 +95,8 @@ namespace Mvc.JQuery.Datatables.Example.Controllers
     public class UserView
     {
         public int Id { get; set; }
+
+        [DisplayName("Full Name")]
         public MvcHtmlString Name { get; set; }
 
         public string Email { get; set; }

--- a/Mvc.JQuery.Datatables.Example/Mvc.JQuery.Datatables.Example.csproj
+++ b/Mvc.JQuery.Datatables.Example/Mvc.JQuery.Datatables.Example.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -15,6 +16,11 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>4.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -234,8 +240,13 @@
       <Name>Mvc.JQuery.Datatables</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Mvc.JQuery.Datatables.Templates/Views/Shared/DataTable.cshtml
+++ b/Mvc.JQuery.Datatables.Templates/Views/Shared/DataTable.cshtml
@@ -8,7 +8,7 @@
         <tr>
             @foreach (var column in Model.Columns)
             {
-                <th>@column.Item1</th>
+                <th>@column.Item2</th>
             }
         </tr>
         @if (Model.ColumnFilter)
@@ -16,7 +16,7 @@
             <tr>
                 @foreach (var column in Model.Columns)
                 {
-                    <th>@column.Item1</th>
+                    <th>@column.Item2</th>
                 }
             </tr>
         }

--- a/Mvc.JQuery.Datatables.sln
+++ b/Mvc.JQuery.Datatables.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvc.JQuery.Datatables", "Mvc.JQuery.Datatables\Mvc.JQuery.Datatables.csproj", "{389ADE94-7C32-4885-812E-68A2A74C82D8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvc.JQuery.Datatables.Example", "Mvc.JQuery.Datatables.Example\Mvc.JQuery.Datatables.Example.csproj", "{476D3266-8699-4E89-A528-646C1235EEB1}"

--- a/Mvc.JQuery.Datatables/DataTableVm.cs
+++ b/Mvc.JQuery.Datatables/DataTableVm.cs
@@ -14,7 +14,7 @@ namespace Mvc.JQuery.Datatables
         public static string DefaultTableClass { get; set; }
         public string TableClass { get; set; }
 
-        public DataTableVm(string id, string ajaxUrl, IEnumerable<Tuple<string, Type>> columns)
+        public DataTableVm(string id, string ajaxUrl, IEnumerable<Tuple<string, string, Type>> columns)
         {
             AjaxUrl = ajaxUrl;
             this.Id = id;
@@ -32,7 +32,7 @@ namespace Mvc.JQuery.Datatables
 
         public string AjaxUrl { get; private set; }
 
-        public IEnumerable<Tuple<string, Type>> Columns { get; private set; }
+        public IEnumerable<Tuple<string, string, Type>> Columns { get; private set; }
 
         public bool ColumnFilter { get; set; }
 
@@ -42,7 +42,7 @@ namespace Mvc.JQuery.Datatables
 
         public string ColumnFiltersString
         {
-            get { return string.Join(",", Columns.Select(c => GetFilterType(c.Item1, c.Item2))); }
+            get { return string.Join(",", Columns.Select(c => GetFilterType(c.Item1, c.Item3))); }
         }
 
         public string Dom

--- a/Mvc.JQuery.Datatables/DataTablesFilter.cs
+++ b/Mvc.JQuery.Datatables/DataTablesFilter.cs
@@ -7,7 +7,7 @@ namespace Mvc.JQuery.Datatables
 {
     public class DataTablesFilter
     {
-        public IQueryable FilterPagingSortingSearch(DataTablesParam dtParameters, IQueryable data, out int totalRecordsDisplay, Tuple<string, Type>[] columns)
+        public IQueryable FilterPagingSortingSearch(DataTablesParam dtParameters, IQueryable data, out int totalRecordsDisplay, Tuple<string, string, Type>[] columns)
         {
             if (!String.IsNullOrEmpty(dtParameters.sSearch))
             {
@@ -156,11 +156,11 @@ namespace Mvc.JQuery.Datatables
             Filters.Add(Guard(Is<T>, filter));
         }
 
-        private static string GetFilterClause(string query, Tuple<string, Type> column, List<object> parametersForLinqQuery)
+        private static string GetFilterClause(string query, Tuple<string, string, Type> column, List<object> parametersForLinqQuery)
         {
             foreach (var filter in Filters)
             {
-                var filteredQuery = filter(query, column.Item1, column.Item2, parametersForLinqQuery);
+                var filteredQuery = filter(query, column.Item1, column.Item3, parametersForLinqQuery);
                 if (filteredQuery != null)
                 {
                     return filteredQuery;

--- a/Mvc.JQuery.Datatables/DataTablesResult.cs
+++ b/Mvc.JQuery.Datatables/DataTablesResult.cs
@@ -51,7 +51,7 @@ namespace Mvc.JQuery.Datatables
             _transform = transform;
             var properties = typeof(TRes).GetProperties();
 
-            var content = GetResults(q, dataTableParam, properties.Select(p => Tuple.Create(p.Name, p.PropertyType)).ToArray());
+            var content = GetResults(q, dataTableParam, properties.Select(p => Tuple.Create(p.Name, (string)null, p.PropertyType)).ToArray());
             this.Data = content;
             this.JsonRequestBehavior = JsonRequestBehavior.DenyGet;
         }
@@ -82,7 +82,7 @@ namespace Mvc.JQuery.Datatables
         {
             PropertyTransformers.Add(Guard<TVal>(filter));
         }
-        private DataTablesData GetResults(IQueryable<T> data, DataTablesParam param, Tuple<string, Type>[] searchColumns)
+        private DataTablesData GetResults(IQueryable<T> data, DataTablesParam param, Tuple<string, string, Type>[] searchColumns)
         {
 
             int totalRecords = data.Count();


### PR DESCRIPTION
There was no way to change the column headings and it defaulted to
showing the property names as the column headings. I have changed that
and it now respects the use of DisplayNameAttribute on the model
classes.
