### PR TITLE
Display(Order=) Attribute support to improve column ordering

### DIFF
--- a/Mvc.JQuery.Datatables/DataTablesHelper.cs
+++ b/Mvc.JQuery.Datatables/DataTablesHelper.cs
@@ -13,7 +13,6 @@ namespace Mvc.JQuery.Datatables
 {
     public static class DataTablesHelper
     {
-
         public static IHtmlString DataTableIncludes(this HtmlHelper helper, bool jqueryUi = false, bool filters = true, bool tableTools = true)
         {
             StringBuilder output = new StringBuilder();
@@ -30,18 +29,18 @@ namespace Mvc.JQuery.Datatables
                 addCss("/Content/DataTables/extras/TableTools/media/css/TableTools.css");
             }
             return helper.Raw(output.ToString());
-
         }
 
         public static DataTableVm DataTableVm<TController, TResult>(this HtmlHelper html, string id, Expression<Func<TController, DataTablesResult<TResult>>> exp, IEnumerable<ColDef> columns = null)
         {
             if (columns == null || !columns.Any())
             {
-                var propInfos = typeof (TResult).GetProperties().Where(p => p.GetGetMethod() != null).ToList();
+                //var propInfos = typeof (TResult).GetProperties().Where(p => p.GetGetMethod() != null).ToList();
+                var propInfos = TypeExtensions.GetSortedProperties<TResult>();
                 var columnList = new List<ColDef>();
                 foreach (var propertyInfo in propInfos)
                 {
-                    var displayNameAttribute = (DisplayNameAttribute) propertyInfo.GetCustomAttributes(typeof (DisplayNameAttribute), false).FirstOrDefault();
+                    var displayNameAttribute = (DisplayNameAttribute)propertyInfo.GetCustomAttributes(typeof(DisplayNameAttribute), false).FirstOrDefault();
                     var displayName = displayNameAttribute == null ? propertyInfo.Name : displayNameAttribute.DisplayName;
                     columnList.Add(new ColDef()
                     {

--- a/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
+++ b/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
@@ -37,6 +37,7 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
@@ -59,6 +60,7 @@
     <Compile Include="DynamicLinq\DynamicLinq.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StaticReflectionHelper.cs" />
+    <Compile Include="TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Views\Shared\DataTable.cshtml">

--- a/Mvc.JQuery.Datatables/TypeExtensions.cs
+++ b/Mvc.JQuery.Datatables/TypeExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+
+public static class TypeExtensions
+{
+    public static IEnumerable<PropertyInfo> GetSortedProperties(this Type t)
+    {
+        return from pi in t.GetProperties()
+               let da = (DisplayAttribute)pi.GetCustomAttributes(typeof(DisplayAttribute), false).SingleOrDefault()
+               let order = ((da != null && da.Order != 0) ? da.Order : int.MaxValue)
+               orderby order
+               select pi;
+    }
+
+    public static IEnumerable<PropertyInfo> GetSortedProperties<T>()
+    {
+        return TypeExtensions.GetSortedProperties(typeof(T));
+    }
+}


### PR DESCRIPTION
Replaced the stock reflection .GetProperties with an ordered properties
that respects the Display(Order=) data annotations for easier ordering
of columns.  A reference to system.componentmodel.dataannotations had to
be added to the project as well.
