### PR TITLE
Added ability to DataTableVm class to set custom JS options

### DIFF
--- a/Mvc.JQuery.Datatables.Example/Views/Home/Index.cshtml
+++ b/Mvc.JQuery.Datatables.Example/Views/Home/Index.cshtml
@@ -53,6 +53,8 @@ can also use
 @using Mvc.JQuery.Datatables.Example.Controllers
 @{
     var vm = Html.DataTableVm("table-id", (HomeController h) => h.GetUsers(null));
+    //vm.JsOptions.Add("iDisplayLength", 25);
+    //vm.JsOptions.Add("aLengthMenu", new object[] { new[] {5, 10, 25, 250, -1} , new object[] { 5, 10, 25, 250, "All"} });
     vm.ColumnFilter = true;
     vm.FilterOn("Position").Select("Engineer", "Tester", "Manager")
         .FilterOn("Id").NumberRange();

--- a/Mvc.JQuery.Datatables.Templates/Views/Shared/DataTable.cshtml
+++ b/Mvc.JQuery.Datatables.Templates/Views/Shared/DataTable.cshtml
@@ -55,6 +55,7 @@
                         "success": fnCallback
                     });
                 }
+                @Html.Raw(!string.IsNullOrWhiteSpace(Model.JsOptionsString) ? ", " + Model.JsOptionsString : "")
             });
             @if (Model.ColumnFilter)
             {

--- a/Mvc.JQuery.Datatables/DataTableVm.cs
+++ b/Mvc.JQuery.Datatables/DataTableVm.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Web.Script.Serialization;
 
 namespace Mvc.JQuery.Datatables
 {
@@ -17,6 +18,8 @@ namespace Mvc.JQuery.Datatables
     }
     public class DataTableVm
     {
+        IDictionary<string, object> m_JsOptions = new Dictionary<string, object>();
+
         static DataTableVm()
         {
             DefaultTableClass = "table table-bordered table-striped";
@@ -44,6 +47,16 @@ namespace Mvc.JQuery.Datatables
         public string AjaxUrl { get; private set; }
 
         public IEnumerable<ColDef> Columns { get; private set; }
+
+        public IDictionary<string, object> JsOptions { get { return m_JsOptions; } }
+
+        public string JsOptionsString
+        {
+            get
+            {
+                return (new JavaScriptSerializer()).Serialize((object)JsOptions).TrimStart('{').TrimEnd('}');
+            }
+        }
 
         public bool ColumnFilter { get; set; }
 

--- a/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
+++ b/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Usage:

var vm = Html.DataTableVm("table-id", (HomeController h) => h.GetUsers(null));
vm.JsOptions.Add("iDisplayLength", 25);
vm.JsOptions.Add("aLengthMenu", new object[] { new[] {5, 10, 25, 250, -1} , new object[] { 5, 10, 25, 250, "All"} });
