### PR TITLE
Wait for dataTables script to load

### DIFF
--- a/Mvc.JQuery.Datatables.Templates/Views/Shared/DataTable.cshtml
+++ b/Mvc.JQuery.Datatables.Templates/Views/Shared/DataTable.cshtml
@@ -33,7 +33,7 @@
 
 <script type="text/javascript">
     (function setDataTable() {
-        if(!window.jQuery) {
+        if(!window.jQuery || !$.fn.DataTable) {
             setTimeout(setDataTable, 100);
             return;
         }


### PR DESCRIPTION
Also wait for the dataTables script to load, allows placing jquery.dataTables.js in the scripts section at the end of the layout page, to avoid needing to put the jQuery and dataTables scripts in <head>
