### PR TITLE
RegisterDatatablesModelBinder namespace fix

### DIFF
--- a/Mvc.JQuery.Datatables/RegisterDatatablesModelBinder.cs.pp
+++ b/Mvc.JQuery.Datatables/RegisterDatatablesModelBinder.cs.pp
@@ -3,7 +3,7 @@ using System.Web.Mvc;
 using System.Web.WebPages;
 using Mvc.JQuery.Datatables;
 
-[assembly: PreApplicationStartMethod(typeof(RegisterDatatablesModelBinder), "Start")]
+[assembly: PreApplicationStartMethod(typeof($rootnamespace$.RegisterDatatablesModelBinder), "Start")]
 
 namespace $rootnamespace$ {
     public static class RegisterDatatablesModelBinder {


### PR DESCRIPTION
Fixes the error: "The type or namespace name 'RegisterDatatablesModelBinder' could not be found (are you missing a using directive or an assembly reference?)" caused by namespace not being part of PreApplicationStartMethod.
