### PR TITLE
Allow initial search values

### DIFF
--- a/Mvc.JQuery.Datatables.Templates/Views/Shared/DataTable.cshtml
+++ b/Mvc.JQuery.Datatables.Templates/Views/Shared/DataTable.cshtml
@@ -57,7 +57,8 @@
                     "success": fnCallback
                 });
             },
-            "aoColumnDefs" : @Html.Raw(Model.ColumnDefsString)
+            "aoColumnDefs" : @Html.Raw(Model.ColumnDefsString),
+            "aoSearchCols": @Html.Raw(Model.ColumnInitialSearchString)
                 @Html.Raw(!string.IsNullOrWhiteSpace(Model.JsOptionsString) ? ", " + Model.JsOptionsString : "")
             @if (!string.IsNullOrEmpty(Model.Language))
             {
@@ -72,7 +73,7 @@
                 </text>
             }
                     });
-            @if (Model.ColumnFilter)
+        @if (Model.ColumnFilter)
             {
                 <text>
         dt.columnFilter(@Html.Raw(Model.ColumnFilterVm.ToString()));

--- a/Mvc.JQuery.Datatables/ColDef.cs
+++ b/Mvc.JQuery.Datatables/ColDef.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Mvc.JQuery.Datatables
 {
@@ -21,6 +22,9 @@ namespace Mvc.JQuery.Datatables
         public SortDirection SortDirection { get; set; }
         public string MRenderFunction { get; set; }
         public FilterDef Filter { get; set; }
+
+        IDictionary<string, object> m_JsInitialSearchCols = new Dictionary<string, object>();
+        public IDictionary<string, object> JsInitialSearchCols { get { return m_JsInitialSearchCols; } }
 
         public static ColDef Create(string name, string p1, Type propertyType, bool visible = true, bool sortable = true,
             SortDirection sortDirection = SortDirection.None, string mRenderFunction = null, string pCssClass = "",

--- a/Mvc.JQuery.Datatables/DataTableConfigVm.cs
+++ b/Mvc.JQuery.Datatables/DataTableConfigVm.cs
@@ -114,7 +114,15 @@ namespace Mvc.JQuery.Datatables
 
         public bool AutoWidth { get; set; }
 
-        
+        public string ColumnInitialSearchString
+        {
+            get
+            {
+                return convertColumnDefsInitialSearchToJson(Columns);
+            }
+        }
+
+
 
         public string Dom
         {
@@ -225,7 +233,17 @@ namespace Mvc.JQuery.Datatables
             IDictionary<string, object> optionsDict = convertObjectToDictionary(jsOptions);
             return FilterOn(columnName, optionsDict); 
         }
+        public _FilterOn<DataTableConfigVm> FilterOn(string columnName, object jsOptions, object jsInitialSearchCols)
+        {
+            IDictionary<string, object> optionsDict = convertObjectToDictionary(jsOptions);
+            IDictionary<string, object> initialSearchColsDict = convertObjectToDictionary(jsInitialSearchCols);
+            return FilterOn(columnName, optionsDict, initialSearchColsDict);
+        }
         public _FilterOn<DataTableConfigVm> FilterOn(string columnName, IDictionary<string, object> jsOptions)
+        {
+            return FilterOn(columnName, jsOptions, null);
+        }
+        public _FilterOn<DataTableConfigVm> FilterOn(string columnName, IDictionary<string, object> jsOptions, IDictionary<string, object> jsInitialSearchCols)
         {
             var colDef = this.Columns.Single(c => c.Name == columnName);
             if (jsOptions != null)
@@ -233,6 +251,13 @@ namespace Mvc.JQuery.Datatables
                 foreach (var jsOption in jsOptions)
                 {
                     colDef.Filter[jsOption.Key] = jsOption.Value;
+                }
+            }
+            if (jsInitialSearchCols != null)
+            {
+                foreach (var jsInitialSearchCol in jsInitialSearchCols)
+                {
+                    colDef.JsInitialSearchCols[jsInitialSearchCol.Key] = jsInitialSearchCol.Value;
                 }
             }
             return new _FilterOn<DataTableConfigVm>(this, colDef);
@@ -277,6 +302,13 @@ namespace Mvc.JQuery.Datatables
                 return new JavaScriptSerializer().Serialize(defs).Replace("\"%", "").Replace("%\"", "");
 
             return "[]";
+        }
+
+        private static string convertColumnDefsInitialSearchToJson(IEnumerable<ColDef> columns)
+        {
+            var initialSearches = columns
+                .Select(c => c.Searchable & c.JsInitialSearchCols.Any() ? c.JsInitialSearchCols : null).ToArray();
+            return new JavaScriptSerializer().Serialize(initialSearches);
         }
 
         private static string convertColumnSortingToJson(IEnumerable<ColDef> columns)


### PR DESCRIPTION
Related to Set initial filter values #93

I couldn't find a way to do this with existing code, so I added the functionality myself. Adds support for the Datatables "aoSearchCols" setting, which the columnFilter plugin uses.

Notes and documentation below:
# Specifying Initial Search Values

Datatables provides the option to define an initial search for individual columns. Documentation for this feature is available on the Datatables web site at https://datatables.net/reference/option/searchCols

mvc.jquery.datatables uses the jquery.dataTables.columnFilter plugin to provide extended filtering capabilities.
## Usage

Append your initial search values to the .FilterOn method. A third parameter accepts an anonymous type to specify search values. The "sSearch" field is required, and the "bEscapeRegex" is optional. 

Search fields can be set to an individual string, or be "~" separated in the case of range values. Any values are case sensitive.

NOTE: If using initial search values, then you must set StateSave to false. This is a current limitation in Datatables, where you cannot have saving of state and setting initial values at the same time.
### Example

```
    vm
        .FilterOn("Position", new { sSelector = "#custom-filter-placeholder-position" }, new { sSearch = "Tester" }).Select("Engineer", "Tester", "Manager")
        .FilterOn("Id", null, new { sSearch = "2~4", bEscapeRegex = false }).NumberRange()
        .FilterOn("IsAdmin", null, new { sSearch = "False" }).Select("True","False")
        .FilterOn("Salary", new { sSelector = "#custom-filter-placeholder-salary" }, new { sSearch = "1000~100000" }).NumberRange();    
    vm.StateSave = false;
```
## Developer Notes

aoSearchCols = searchCols, in the upgrade to Datatables v1.10, the option was changed from "aoSearchCols" to "searchCols" (as well as "sSearch" -> "search" and "bEscapeRegex" -> "escapeRegex". The setting "aoSearchCols" is still valid in v1.10, and to be consistent with the existing settings used by mvc.jquery.datatables, the v1.9 setting value has been used.
