### PR TITLE
Added support for output as an array of objects for newer versions of datatables.js

### DIFF
--- a/Mvc.JQuery.Datatables/DataTablesResult.cs
+++ b/Mvc.JQuery.Datatables/DataTablesResult.cs
@@ -1,16 +1,16 @@
-using System.Web;
-using System.Web.Script.Serialization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web.Mvc;
 using Mvc.JQuery.Datatables.Models;
 using Mvc.JQuery.Datatables.Reflection;
 using Mvc.JQuery.Datatables.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.Script.Serialization;
 
 namespace Mvc.JQuery.Datatables
 {
-    public abstract class DataTablesResult  : ActionResult
+    public abstract class DataTablesResult : ActionResult
     {
         /// <typeparam name="TSource"></typeparam>
         /// <typeparam name="TTransform"></typeparam>
@@ -18,60 +18,83 @@ namespace Mvc.JQuery.Datatables
         /// <param name="dataTableParam"></param>
         /// <param name="transform">//a transform for custom column rendering e.g. to do a custom date row => new { CreatedDate = row.CreatedDate.ToString("dd MM yy") } </param>
         /// <returns></returns>
-        public static DataTablesResult<TSource> Create<TSource, TTransform>(IQueryable<TSource> q, DataTablesParam dataTableParam, Func<TSource, TTransform> transform)
+        public static DataTablesResult<TSource> Create<TSource, TTransform>(IQueryable<TSource> q, DataTablesParam dataTableParam,
+            Func<TSource, TTransform> transform, ArrayOutputType? arrayOutput = null)
         {
             var result = new DataTablesResult<TSource>(q, dataTableParam);
+
             result.Data = result.Data
                 .Transform<TSource, Dictionary<string, object>>(row => TransformTypeInfo.MergeTransformValuesIntoDictionary(transform, row))
-                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues)
-                .Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray());
-                
+                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues);
+
+            result.Data = ApplyOutputRules(result.Data, arrayOutput);
+
             return result;
         }
 
-        public static DataTablesResult<TSource> Create<TSource>(IQueryable<TSource> q, DataTablesParam dataTableParam)
+        public static DataTablesResult<TSource> Create<TSource>(IQueryable<TSource> q, DataTablesParam dataTableParam,
+            ArrayOutputType? arrayOutput = null)
         {
             var result = new DataTablesResult<TSource>(q, dataTableParam);
 
             result.Data = result.Data
                 .Transform<TSource, Dictionary<string, object>>(DataTablesTypeInfo<TSource>.ToDictionary)
-                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues)
-                .Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray()); ;
+                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues);
+
+            result.Data = ApplyOutputRules(result.Data, arrayOutput);
+
             return result;
         }
 
+        private static DataTablesData ApplyOutputRules(DataTablesData sourceData, ArrayOutputType? arrayOutput = null)
+        {
+            DataTablesData outputData = sourceData;
+
+            switch (arrayOutput)
+            {
+                case ArrayOutputType.ArrayOfObjects:
+                    // Nothing is needed
+                    break;
+                case ArrayOutputType.BiDimensionalArray:
+                default:
+                    outputData = sourceData.Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray());
+                    break;
+            }
+
+            return outputData;
+        }
 
         /// <param name="transform">Should be a Func<T, TTransform></param>
-        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam, object transform)
+        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam, object transform,
+            ArrayOutputType? arrayOutput = null)
         {
             var s = "Create";
             var openCreateMethod = typeof(DataTablesResult).GetMethods().Single(x => x.Name == s && x.GetGenericArguments().Count() == 2);
             var queryableType = queryable.GetType().GetGenericArguments()[0];
             var transformType = transform.GetType().GetGenericArguments()[1];
             var closedCreateMethod = openCreateMethod.MakeGenericMethod(queryableType, transformType);
-            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, transform });
+            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, transform, arrayOutput });
         }
 
-        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam)
+        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam,
+            ArrayOutputType? arrayOutput = null)
         {
             var s = "Create";
             var openCreateMethod = typeof(DataTablesResult).GetMethods().Single(x => x.Name == s && x.GetGenericArguments().Count() == 1);
             var queryableType = queryable.GetType().GetGenericArguments()[0];
             var closedCreateMethod = openCreateMethod.MakeGenericMethod(queryableType);
-            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam });
+            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, arrayOutput });
         }
 
-        public static DataTablesResult<T> CreateResultUsingEnumerable<T>(IEnumerable<T> q, DataTablesParam dataTableParam)
+        public static DataTablesResult<T> CreateResultUsingEnumerable<T>(IEnumerable<T> q, DataTablesParam dataTableParam,
+            ArrayOutputType? arrayOutput = null)
         {
-            return Create(q.AsQueryable(), dataTableParam);
+            return Create(q.AsQueryable(), dataTableParam, arrayOutput);
         }
- 
     }
-
 
     public class DataTablesResult<TSource> : DataTablesResult
     {
-
         public DataTablesData Data { get; set; }
 
         internal DataTablesResult(IQueryable<TSource> q, DataTablesParam dataTableParam)
@@ -87,18 +110,20 @@ namespace Mvc.JQuery.Datatables
         {
             if (context == null)
                 throw new ArgumentNullException("context");
+
             HttpResponseBase response = context.HttpContext.Response;
 
             var scriptSerializer = new JavaScriptSerializer()
             {
                 MaxJsonLength = int.MaxValue
             };
+
             response.Write(scriptSerializer.Serialize(this.Data));
         }
 
         DataTablesData GetResults(IQueryable<TSource> data, DataTablesParam param)
         {
-            var totalRecords = data.Count(); //annoying this, as it causes an extra evaluation..
+            var totalRecords = data.Count(); // annoying this, as it causes an extra evaluation..
 
             var filters = new DataTablesFiltering();
 
@@ -110,7 +135,6 @@ namespace Mvc.JQuery.Datatables
             var skipped = filteredData.Skip(param.iDisplayStart);
             var page = (param.iDisplayLength <= 0 ? skipped : skipped.Take(param.iDisplayLength)).ToArray();
 
-            
             var result = new DataTablesData
             {
                 iTotalRecords = totalRecords,
@@ -121,7 +145,5 @@ namespace Mvc.JQuery.Datatables
 
             return result;
         }
-
-        
     }
 }

--- a/Mvc.JQuery.Datatables/DataTablesResult.cs
+++ b/Mvc.JQuery.Datatables/DataTablesResult.cs
@@ -1,12 +1,12 @@
-using System.Web;
-using System.Web.Script.Serialization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web.Mvc;
 using Mvc.JQuery.Datatables.Models;
 using Mvc.JQuery.Datatables.Reflection;
 using Mvc.JQuery.Datatables.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.Script.Serialization;
 
 namespace Mvc.JQuery.Datatables
 {
@@ -18,60 +18,83 @@ namespace Mvc.JQuery.Datatables
         /// <param name="dataTableParam"></param>
         /// <param name="transform">//a transform for custom column rendering e.g. to do a custom date row => new { CreatedDate = row.CreatedDate.ToString("dd MM yy") } </param>
         /// <returns></returns>
-        public static DataTablesResult<TSource> Create<TSource, TTransform>(IQueryable<TSource> q, DataTablesParam dataTableParam, Func<TSource, TTransform> transform)
+        public static DataTablesResult<TSource> Create<TSource, TTransform>(IQueryable<TSource> q, DataTablesParam dataTableParam, 
+            Func<TSource, TTransform> transform, ArrayOutputType? arrayOutput = null)
         {
             var result = new DataTablesResult<TSource>(q, dataTableParam);
+
             result.Data = result.Data
                 .Transform<TSource, Dictionary<string, object>>(row => TransformTypeInfo.MergeTransformValuesIntoDictionary(transform, row))
-                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues)
-                .Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray());
+                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues);
+
+            result.Data = ApplyOutputRules(result.Data, arrayOutput);
                 
             return result;
         }
 
-        public static DataTablesResult<TSource> Create<TSource>(IQueryable<TSource> q, DataTablesParam dataTableParam)
+        public static DataTablesResult<TSource> Create<TSource>(IQueryable<TSource> q, DataTablesParam dataTableParam, 
+            ArrayOutputType? arrayOutput = null)
         {
             var result = new DataTablesResult<TSource>(q, dataTableParam);
 
             result.Data = result.Data
                 .Transform<TSource, Dictionary<string, object>>(DataTablesTypeInfo<TSource>.ToDictionary)
-                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues)
-                .Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray()); ;
+                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues);
+
+            result.Data = ApplyOutputRules(result.Data, arrayOutput);
+
             return result;
         }
 
+        private static DataTablesData ApplyOutputRules(DataTablesData sourceData, ArrayOutputType? arrayOutput = null)
+        {
+            DataTablesData outputData = sourceData;
+
+            switch (arrayOutput)
+            {
+                case ArrayOutputType.ArrayOfObjects:
+                    // Nothing is needed
+                    break;
+                case ArrayOutputType.BiDimensionalArray:
+                default:
+                    outputData = sourceData.Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray());
+                    break;
+            }
+
+            return outputData;
+        }
 
         /// <param name="transform">Should be a Func<T, TTransform></param>
-        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam, object transform)
+        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam, object transform, 
+            ArrayOutputType? arrayOutput = null)
         {
             var s = "Create";
             var openCreateMethod = typeof(DataTablesResult).GetMethods().Single(x => x.Name == s && x.GetGenericArguments().Count() == 2);
             var queryableType = queryable.GetType().GetGenericArguments()[0];
             var transformType = transform.GetType().GetGenericArguments()[1];
             var closedCreateMethod = openCreateMethod.MakeGenericMethod(queryableType, transformType);
-            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, transform });
+            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, transform, arrayOutput });
         }
 
-        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam)
+        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam, 
+            ArrayOutputType? arrayOutput = null)
         {
             var s = "Create";
             var openCreateMethod = typeof(DataTablesResult).GetMethods().Single(x => x.Name == s && x.GetGenericArguments().Count() == 1);
             var queryableType = queryable.GetType().GetGenericArguments()[0];
             var closedCreateMethod = openCreateMethod.MakeGenericMethod(queryableType);
-            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam });
+            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, arrayOutput });
         }
 
-        public static DataTablesResult<T> CreateResultUsingEnumerable<T>(IEnumerable<T> q, DataTablesParam dataTableParam)
+        public static DataTablesResult<T> CreateResultUsingEnumerable<T>(IEnumerable<T> q, DataTablesParam dataTableParam, 
+            ArrayOutputType? arrayOutput = null)
         {
-            return Create(q.AsQueryable(), dataTableParam);
+            return Create(q.AsQueryable(), dataTableParam, arrayOutput);
         }
- 
     }
-
 
     public class DataTablesResult<TSource> : DataTablesResult
     {
-
         public DataTablesData Data { get; set; }
 
         internal DataTablesResult(IQueryable<TSource> q, DataTablesParam dataTableParam)
@@ -87,18 +110,20 @@ namespace Mvc.JQuery.Datatables
         {
             if (context == null)
                 throw new ArgumentNullException("context");
+
             HttpResponseBase response = context.HttpContext.Response;
 
             var scriptSerializer = new JavaScriptSerializer()
             {
                 MaxJsonLength = int.MaxValue
             };
+
             response.Write(scriptSerializer.Serialize(this.Data));
         }
 
         DataTablesData GetResults(IQueryable<TSource> data, DataTablesParam param)
         {
-            var totalRecords = data.Count(); //annoying this, as it causes an extra evaluation..
+            var totalRecords = data.Count(); // annoying this, as it causes an extra evaluation..
 
             var filters = new DataTablesFiltering();
 
@@ -109,7 +134,6 @@ namespace Mvc.JQuery.Datatables
 
             var skipped = filteredData.Skip(param.iDisplayStart);
             var page = (param.iDisplayLength <= 0 ? skipped : skipped.Take(param.iDisplayLength)).ToArray();
-
             
             var result = new DataTablesData
             {
@@ -121,7 +145,5 @@ namespace Mvc.JQuery.Datatables
 
             return result;
         }
-
-        
     }
 }

--- a/Mvc.JQuery.Datatables/DataTablesResult.cs
+++ b/Mvc.JQuery.Datatables/DataTablesResult.cs
@@ -1,12 +1,12 @@
-using Mvc.JQuery.Datatables.Models;
-using Mvc.JQuery.Datatables.Reflection;
-using Mvc.JQuery.Datatables.Util;
+using System.Web;
+using System.Web.Script.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using System.Web.Mvc;
-using System.Web.Script.Serialization;
+using Mvc.JQuery.Datatables.Models;
+using Mvc.JQuery.Datatables.Reflection;
+using Mvc.JQuery.Datatables.Util;
 
 namespace Mvc.JQuery.Datatables
 {
@@ -18,83 +18,60 @@ namespace Mvc.JQuery.Datatables
         /// <param name="dataTableParam"></param>
         /// <param name="transform">//a transform for custom column rendering e.g. to do a custom date row => new { CreatedDate = row.CreatedDate.ToString("dd MM yy") } </param>
         /// <returns></returns>
-        public static DataTablesResult<TSource> Create<TSource, TTransform>(IQueryable<TSource> q, DataTablesParam dataTableParam, 
-            Func<TSource, TTransform> transform, ArrayOutputType? arrayOutput = null)
+        public static DataTablesResult<TSource> Create<TSource, TTransform>(IQueryable<TSource> q, DataTablesParam dataTableParam, Func<TSource, TTransform> transform)
         {
             var result = new DataTablesResult<TSource>(q, dataTableParam);
-
             result.Data = result.Data
                 .Transform<TSource, Dictionary<string, object>>(row => TransformTypeInfo.MergeTransformValuesIntoDictionary(transform, row))
-                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues);
-
-            result.Data = ApplyOutputRules(result.Data, arrayOutput);
+                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues)
+                .Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray());
                 
             return result;
         }
 
-        public static DataTablesResult<TSource> Create<TSource>(IQueryable<TSource> q, DataTablesParam dataTableParam, 
-            ArrayOutputType? arrayOutput = null)
+        public static DataTablesResult<TSource> Create<TSource>(IQueryable<TSource> q, DataTablesParam dataTableParam)
         {
             var result = new DataTablesResult<TSource>(q, dataTableParam);
 
             result.Data = result.Data
                 .Transform<TSource, Dictionary<string, object>>(DataTablesTypeInfo<TSource>.ToDictionary)
-                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues);
-
-            result.Data = ApplyOutputRules(result.Data, arrayOutput);
-
+                .Transform<Dictionary<string, object>, Dictionary<string, object>>(StringTransformers.StringifyValues)
+                .Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray()); ;
             return result;
         }
 
-        private static DataTablesData ApplyOutputRules(DataTablesData sourceData, ArrayOutputType? arrayOutput = null)
-        {
-            DataTablesData outputData = sourceData;
-
-            switch (arrayOutput)
-            {
-                case ArrayOutputType.ArrayOfObjects:
-                    // Nothing is needed
-                    break;
-                case ArrayOutputType.BiDimensionalArray:
-                default:
-                    outputData = sourceData.Transform<Dictionary<string, object>, object[]>(d => d.Values.ToArray());
-                    break;
-            }
-
-            return outputData;
-        }
 
         /// <param name="transform">Should be a Func<T, TTransform></param>
-        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam, object transform, 
-            ArrayOutputType? arrayOutput = null)
+        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam, object transform)
         {
             var s = "Create";
             var openCreateMethod = typeof(DataTablesResult).GetMethods().Single(x => x.Name == s && x.GetGenericArguments().Count() == 2);
             var queryableType = queryable.GetType().GetGenericArguments()[0];
             var transformType = transform.GetType().GetGenericArguments()[1];
             var closedCreateMethod = openCreateMethod.MakeGenericMethod(queryableType, transformType);
-            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, transform, arrayOutput });
+            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, transform });
         }
 
-        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam, 
-            ArrayOutputType? arrayOutput = null)
+        public static DataTablesResult Create(IQueryable queryable, DataTablesParam dataTableParam)
         {
             var s = "Create";
             var openCreateMethod = typeof(DataTablesResult).GetMethods().Single(x => x.Name == s && x.GetGenericArguments().Count() == 1);
             var queryableType = queryable.GetType().GetGenericArguments()[0];
             var closedCreateMethod = openCreateMethod.MakeGenericMethod(queryableType);
-            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam, arrayOutput });
+            return (DataTablesResult)closedCreateMethod.Invoke(null, new object[] { queryable, dataTableParam });
         }
 
-        public static DataTablesResult<T> CreateResultUsingEnumerable<T>(IEnumerable<T> q, DataTablesParam dataTableParam, 
-            ArrayOutputType? arrayOutput = null)
+        public static DataTablesResult<T> CreateResultUsingEnumerable<T>(IEnumerable<T> q, DataTablesParam dataTableParam)
         {
-            return Create(q.AsQueryable(), dataTableParam, arrayOutput);
+            return Create(q.AsQueryable(), dataTableParam);
         }
+ 
     }
+
 
     public class DataTablesResult<TSource> : DataTablesResult
     {
+
         public DataTablesData Data { get; set; }
 
         internal DataTablesResult(IQueryable<TSource> q, DataTablesParam dataTableParam)
@@ -110,20 +87,18 @@ namespace Mvc.JQuery.Datatables
         {
             if (context == null)
                 throw new ArgumentNullException("context");
-
             HttpResponseBase response = context.HttpContext.Response;
 
             var scriptSerializer = new JavaScriptSerializer()
             {
                 MaxJsonLength = int.MaxValue
             };
-
             response.Write(scriptSerializer.Serialize(this.Data));
         }
 
         DataTablesData GetResults(IQueryable<TSource> data, DataTablesParam param)
         {
-            var totalRecords = data.Count(); // annoying this, as it causes an extra evaluation..
+            var totalRecords = data.Count(); //annoying this, as it causes an extra evaluation..
 
             var filters = new DataTablesFiltering();
 
@@ -134,6 +109,7 @@ namespace Mvc.JQuery.Datatables
 
             var skipped = filteredData.Skip(param.iDisplayStart);
             var page = (param.iDisplayLength <= 0 ? skipped : skipped.Take(param.iDisplayLength)).ToArray();
+
             
             var result = new DataTablesData
             {
@@ -145,5 +121,7 @@ namespace Mvc.JQuery.Datatables
 
             return result;
         }
+
+        
     }
 }

--- a/Mvc.JQuery.Datatables/Models/ArrayOutputType.cs
+++ b/Mvc.JQuery.Datatables/Models/ArrayOutputType.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Mvc.JQuery.Datatables.Models
+{
+    public enum ArrayOutputType
+    {
+        BiDimensionalArray,
+        ArrayOfObjects
+    }
+}

--- a/Mvc.JQuery.Datatables/Models/ArrayOutputType.cs
+++ b/Mvc.JQuery.Datatables/Models/ArrayOutputType.cs
@@ -1,9 +1,0 @@
-﻿
-namespace Mvc.JQuery.Datatables.Models
-{
-    public enum ArrayOutputType
-    {
-        BiDimensionalArray,
-        ArrayOfObjects
-    }
-}

--- a/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
+++ b/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
@@ -82,7 +82,6 @@
     <Compile Include="DataTablesFiltering.cs" />
     <Compile Include="DataTablesFilterAttribute.cs" />
     <Compile Include="LengthMenuVm.cs" />
-    <Compile Include="Models\ArrayOutputType.cs" />
     <Compile Include="Models\ColDef.cs" />
     <Compile Include="ColumnFilterSettingsVm.cs" />
     <Compile Include="DataTablesAttribute.cs" />
@@ -123,11 +122,25 @@
     <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Views\Shared\DataTable.cshtml">
       <Link>Views\Shared\DataTable.cshtml</Link>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Content\jquery-datatables-column-filter\media\js\jquery.dataTables.columnFilter.js">
+      <Link>Content\jquery-datatables-column-filter\media\js\jquery.dataTables.columnFilter.js</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Content\jquery-datatables-column-filter\jquery-ui-timepicker-addon.css">
+      <Link>Content\jquery-datatables-column-filter\jquery-ui-timepicker-addon.css</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Content\jquery-datatables-column-filter\jquery-ui-timepicker-addon.js">
+      <Link>Content\jquery-datatables-column-filter\jquery-ui-timepicker-addon.js</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Content\jquery-datatables-column-filter\media\js\jquery.dataTables.columnFilter.css">
+      <Link>Content\jquery-datatables-column-filter\media\js\jquery.dataTables.columnFilter.css</Link>
+    </EmbeddedResource>
     <Content Include="RegisterDatatablesModelBinder.cs.pp" />
     <None Include="packages.config" />
     <None Include="Views\Web.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Scripts\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
+++ b/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
@@ -82,6 +82,7 @@
     <Compile Include="DataTablesFiltering.cs" />
     <Compile Include="DataTablesFilterAttribute.cs" />
     <Compile Include="LengthMenuVm.cs" />
+    <Compile Include="Models\ArrayOutputType.cs" />
     <Compile Include="Models\ColDef.cs" />
     <Compile Include="ColumnFilterSettingsVm.cs" />
     <Compile Include="DataTablesAttribute.cs" />
@@ -122,25 +123,11 @@
     <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Views\Shared\DataTable.cshtml">
       <Link>Views\Shared\DataTable.cshtml</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Content\jquery-datatables-column-filter\media\js\jquery.dataTables.columnFilter.js">
-      <Link>Content\jquery-datatables-column-filter\media\js\jquery.dataTables.columnFilter.js</Link>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Content\jquery-datatables-column-filter\jquery-ui-timepicker-addon.css">
-      <Link>Content\jquery-datatables-column-filter\jquery-ui-timepicker-addon.css</Link>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Content\jquery-datatables-column-filter\jquery-ui-timepicker-addon.js">
-      <Link>Content\jquery-datatables-column-filter\jquery-ui-timepicker-addon.js</Link>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Mvc.JQuery.Datatables.Templates\Content\jquery-datatables-column-filter\media\js\jquery.dataTables.columnFilter.css">
-      <Link>Content\jquery-datatables-column-filter\media\js\jquery.dataTables.columnFilter.css</Link>
-    </EmbeddedResource>
     <Content Include="RegisterDatatablesModelBinder.cs.pp" />
     <None Include="packages.config" />
     <None Include="Views\Web.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Scripts\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
+++ b/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
@@ -82,6 +82,7 @@
     <Compile Include="DataTablesFiltering.cs" />
     <Compile Include="DataTablesFilterAttribute.cs" />
     <Compile Include="LengthMenuVm.cs" />
+    <Compile Include="Models\ArrayOutputType.cs" />
     <Compile Include="Models\ColDef.cs" />
     <Compile Include="ColumnFilterSettingsVm.cs" />
     <Compile Include="DataTablesAttribute.cs" />


### PR DESCRIPTION
Regarding suggestion on issue: https://github.com/mcintyre321/mvc.jquery.datatables/issues/117

I removed the embedded resources from the project file because it wasn't compiling. It's referenced but not under version control.