### PR TITLE
Added ResponseOptions to DataTablesResult method calls to pass in additional response configuration.  Added support for emitting DT_RowID in ArrayOfObjects output.

### DIFF
--- a/Mvc.JQuery.Datatables/DataTablesFiltering.cs
+++ b/Mvc.JQuery.Datatables/DataTablesFiltering.cs
@@ -31,15 +31,16 @@ namespace Mvc.JQuery.Datatables
                 var values = parts.Where(p => p != null);
                 data = data.Where(string.Join(" or ", values), parameters.ToArray());
             }
-            for (int i = 0; i < dtParameters.sSearchColumns.Count; i++)
+            for (int i = 0; i < dtParameters.sSearchValues.Count; i++)
             {
                 if (dtParameters.bSearchable[i])
                 {
-                    var searchColumn = dtParameters.sSearchColumns[i];
+                    var searchColumn = dtParameters.sSearchValues[i];
                     if (!string.IsNullOrWhiteSpace(searchColumn))
                     {
+                        DataTablesPropertyInfo column = FindColumn(dtParameters, columns, i);
                         var parameters = new List<object>();
-                        var filterClause = GetFilterClause(dtParameters.sSearchColumns[i], columns[i], parameters);
+                        var filterClause = GetFilterClause(searchColumn, column, parameters);
                         if (string.IsNullOrWhiteSpace(filterClause) == false)
                         {
                             data = data.Where(filterClause, parameters.ToArray());
@@ -50,9 +51,9 @@ namespace Mvc.JQuery.Datatables
             string sortString = "";
             for (int i = 0; i < dtParameters.iSortingCols; i++)
             {
-
                 int columnNumber = dtParameters.iSortCol[i];
-                string columnName = columns[columnNumber].PropertyInfo.Name;
+                DataTablesPropertyInfo column = FindColumn(dtParameters, columns, i);
+                string columnName = column.PropertyInfo.Name;
                 string sortDir = dtParameters.sSortDir[i];
                 if (i != 0)
                     sortString += ", ";
@@ -66,6 +67,18 @@ namespace Mvc.JQuery.Datatables
 
 
             return data;
+        }
+
+        private DataTablesPropertyInfo FindColumn(DataTablesParam dtParameters, DataTablesPropertyInfo[] columns, int i)
+        {
+            if (dtParameters.sColumnNames.Any())
+            {
+                return columns.First(x => x.PropertyInfo.Name == dtParameters.sColumnNames[i]);
+            }
+            else
+            {
+                return columns[i];
+            }
         }
 
         public delegate string ReturnedFilteredQueryForType(

--- a/Mvc.JQuery.Datatables/DataTablesFiltering.cs
+++ b/Mvc.JQuery.Datatables/DataTablesFiltering.cs
@@ -52,7 +52,7 @@ namespace Mvc.JQuery.Datatables
             for (int i = 0; i < dtParameters.iSortingCols; i++)
             {
                 int columnNumber = dtParameters.iSortCol[i];
-                DataTablesPropertyInfo column = FindColumn(dtParameters, columns, i);
+                DataTablesPropertyInfo column = FindColumn(dtParameters, columns, columnNumber);
                 string columnName = column.PropertyInfo.Name;
                 string sortDir = dtParameters.sSortDir[i];
                 if (i != 0)

--- a/Mvc.JQuery.Datatables/DataTablesParam.cs
+++ b/Mvc.JQuery.Datatables/DataTablesParam.cs
@@ -15,18 +15,20 @@ namespace Mvc.JQuery.Datatables
         public bool bEscapeRegex { get; set; }
         public int iSortingCols { get; set; }
         public int sEcho { get; set; }
+        public List<string> sColumnNames { get; set; }
         public List<bool> bSortable { get; set; }
         public List<bool> bSearchable { get; set; }
-        public List<string> sSearchColumns { get; set; }
+        public List<string> sSearchValues { get; set; }
         public List<int> iSortCol { get; set; }
         public List<string> sSortDir { get; set; }
         public List<bool> bEscapeRegexColumns { get; set; }
 
         public DataTablesParam()
         {
+            sColumnNames = new List<string>();
             bSortable = new List<bool>();
             bSearchable = new List<bool>();
-            sSearchColumns = new List<string>();
+            sSearchValues = new List<string>();
             iSortCol = new List<int>();
             sSortDir = new List<string>();
             bEscapeRegexColumns = new List<bool>();
@@ -35,9 +37,10 @@ namespace Mvc.JQuery.Datatables
         public DataTablesParam(int iColumns)
         {
             this.iColumns = iColumns;
+            sColumnNames = new List<string>(iColumns);
             bSortable = new List<bool>(iColumns);
             bSearchable = new List<bool>(iColumns);
-            sSearchColumns = new List<string>(iColumns);
+            sSearchValues = new List<string>(iColumns);
             iSortCol = new List<int>(iColumns);
             sSortDir = new List<string>(iColumns);
             bEscapeRegexColumns = new List<bool>(iColumns);

--- a/Mvc.JQuery.Datatables/DataTablesRowIdAttribute.cs
+++ b/Mvc.JQuery.Datatables/DataTablesRowIdAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Mvc.JQuery.Datatables.Models;
+
+namespace Mvc.JQuery.Datatables
+{
+    public class DataTablesRowIdAttribute : DataTablesAttributeBase
+    {
+        public bool EmitAsColumnName { get; set; }
+
+        public override void ApplyTo(ColDef colDef, PropertyInfo pi)
+        {
+            // This attribute does not affect rendering
+        }
+
+        public DataTablesRowIdAttribute()
+        {
+            EmitAsColumnName = true;
+        }
+    }
+}

--- a/Mvc.JQuery.Datatables/Models/DataTablesData.cs
+++ b/Mvc.JQuery.Datatables/Models/DataTablesData.cs
@@ -11,7 +11,7 @@ namespace Mvc.JQuery.Datatables.Models
         public object[] aaData { get; set; }
 
      
-        public DataTablesData Transform<TData, TTransform>(Func<TData, TTransform> transformRow)
+        public DataTablesData Transform<TData, TTransform>(Func<TData, TTransform> transformRow, ResponseOptions responseOptions = null)
         {
             var data = new DataTablesData 
             {

--- a/Mvc.JQuery.Datatables/Models/ResponseOptions.cs
+++ b/Mvc.JQuery.Datatables/Models/ResponseOptions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mvc.JQuery.Datatables.Models
+{
+    public class ResponseOptions
+    {
+        public virtual ArrayOutputType? ArrayOutputType { get; set; }
+
+        public static ResponseOptions<TSource> For<TSource>(IQueryable<TSource> data, 
+            Action<ResponseOptions<TSource>> setOptions) where TSource : class
+        {
+            var responseOptions = new ResponseOptions<TSource>();
+            setOptions(responseOptions);
+            return responseOptions;
+        }
+    }
+
+    public class ResponseOptions<TSource> : ResponseOptions
+    {
+        public Func<TSource, object> DT_RowID
+        {
+            get
+            {
+                return dt_rowid;
+            }
+            set
+            {
+                dt_rowid = value;
+                if (value != null)
+                {
+                    ArrayOutputType = Models.ArrayOutputType.ArrayOfObjects;
+                }
+            }
+        }
+        private Func<TSource, object> dt_rowid;
+
+        public override ArrayOutputType? ArrayOutputType
+        {
+            get { return base.ArrayOutputType; }
+            set
+            {
+                if (DT_RowID != null && value != Models.ArrayOutputType.ArrayOfObjects)
+                {
+                    throw new ArgumentOutOfRangeException("ArrayOutputType", "ArrayOutputType must be ArrayOfObjects when DT_RowID is set");
+                }
+                base.ArrayOutputType = value;
+            }
+        }
+    }
+}

--- a/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
+++ b/Mvc.JQuery.Datatables/Mvc.JQuery.Datatables.csproj
@@ -82,6 +82,7 @@
     <Compile Include="DataTablesExcludeAttribute.cs" />
     <Compile Include="DataTablesFiltering.cs" />
     <Compile Include="DataTablesFilterAttribute.cs" />
+    <Compile Include="DataTablesRowIdAttribute.cs" />
     <Compile Include="LengthMenuVm.cs" />
     <Compile Include="Models\ArrayOutputType.cs" />
     <Compile Include="Models\ColDef.cs" />
@@ -105,6 +106,7 @@
     <Compile Include="DynamicLinq\Signature.cs" />
     <Compile Include="FilterDef.cs" />
     <Compile Include="Models\Language.cs" />
+    <Compile Include="Models\ResponseOptions.cs" />
     <Compile Include="Reflection\DataTablesPropertyInfo.cs" />
     <Compile Include="Reflection\DataTablesTypeInfo.cs" />
     <Compile Include="Reflection\DataTablesTypeInfoHelper.cs" />


### PR DESCRIPTION
=== Response Options ===
Added ResponseOptions parameters to DataTablesResult method calls
Changed arrayOutput method signatures to wrap arrayOutput into ResponseOptions

=== DT_RowID ===
Added DT_RowID to ResponseOptions, allows selection of DT_RowID column in each DataTablesResult.Create call - implicitly sets ResponseOptions.ArrayOutputType to ArrayOfObjects.
Added DataTablesRowIdAttribute to set DT_RowID at the class level; also allows exclusion of the attributed property from being emitted under its normal column name
ResponseOptions.DT_RowID -overrides- DataTablesRowIdAttribute
If a class property has DataTablesRowIdAttribute and DataTablesExcludeAttribute, then DataTablesRowIdAttribute will have no effect
DataTablesRowIdAttribute and DT_RowID only affect conversion of a row to a Dictionary (via DataTablesTypeInfo.ToDictionary)