### PR TITLE
ColDefs serialization fix & refactoring.

### DIFF
--- a/Mvc.JQuery.Datatables.Example/Mvc.JQuery.Datatables.Example.csproj
+++ b/Mvc.JQuery.Datatables.Example/Mvc.JQuery.Datatables.Example.csproj
@@ -52,8 +52,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EmbeddedResourceVirtualPathProvider, Version=1.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\EmbeddedResourceVirtualPathProvider\EmbeddedResourceVirtualPathProvider\bin\Debug\EmbeddedResourceVirtualPathProvider.dll</HintPath>
+      <HintPath>..\packages\EmbeddedResourceVirtualPathProvider.1.3.2\lib\net40\EmbeddedResourceVirtualPathProvider.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework">
       <HintPath>..\packages\EntityFramework.6.1.1\lib\net45\EntityFramework.dll</HintPath>

--- a/Mvc.JQuery.Datatables.Example/packages.config
+++ b/Mvc.JQuery.Datatables.Example/packages.config
@@ -4,11 +4,11 @@
   <package id="EmbeddedResourceVirtualPathProvider" version="1.3.2" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
   <package id="jQuery" version="2.1.4" targetFramework="net45" />
-  <package id="jquery-globalize" version="0.1.1" targetFramework="net4" />
   <package id="jQuery.UI.Combined" version="1.11.4" targetFramework="net45" />
   <package id="jQuery.UI.i18n" version="1.10.2" targetFramework="net4" />
   <package id="jQuery.Validation" version="1.8.0.1" targetFramework="net45" />
   <package id="jQuery.vsdoc" version="1.6" targetFramework="net4" />
+  <package id="jquery-globalize" version="0.1.1" targetFramework="net4" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />


### PR DESCRIPTION
# General description
Fixed:
 - serialization of ColDef.MRenderFunction property in DataTableConfigVm.cs (now it's possible to use any JavaScript expression in its value);
 - reference to EmbeddedResourceVirtualPathProvider in Mvc.JQuery.Datatables.Example.csproj.

Refactored DataTableConfigVm.ConvertColumnDefsToJson to simplify adding serialization of new ColDef properties.

# MRenderFunction property issue
According to DataTables [documentation](https://datatables.net/reference/option/columns.render) it's possible to specify function or string for rendering particular column. Before the fix when setting MRenderFunction like this:
```CSharp
var customColumn = new ColDef(){
  MRenderFunction = "'MyComplexProperty.NestedValue'"
}
```
You'll get something like:
```javascript
{"mRender":\u0027MyComplexProperty.NestedValue\u0027,"aTargets":[5]}
```
Similar thing with double qoutes.
This behavior is caused by usage of JavaScriptSerializer & tricky double quotes trimming.