### PR TITLE
Increase System.Linq.Dynamic.Core version to current latest

### DIFF
--- a/Mvc.JQuery.DataTables.Common/Mvc.JQuery.DataTables.Common.csproj
+++ b/Mvc.JQuery.DataTables.Common/Mvc.JQuery.DataTables.Common.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.0.6.10" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.0.7.5" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Views\**\*;Content\**\*;Scripts\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />


### PR DESCRIPTION
Supposed to address #165. Not sure if this is rather a problem with System.Linq.Dynamic.Core itself or my dev environment though.