### PR TITLE
Convert range filter dates to universaltime

### DIFF
--- a/Mvc.JQuery.DataTables.Common/Processing/TypeFilters.cs
+++ b/Mvc.JQuery.DataTables.Common/Processing/TypeFilters.cs
@@ -111,12 +111,14 @@ namespace Mvc.JQuery.DataTables
                 DateTimeOffset start, end;
                 if (DateTimeOffset.TryParse(parts[0] ?? "", out start))
                 {
+                    start = start.ToUniversalTime();
                     filterString = columnname + " >= @" + parametersForLinqQuery.Count;
                     parametersForLinqQuery.Add(start);
                 }
 
                 if (DateTimeOffset.TryParse(parts[1] ?? "", out end))
                 {
+                    end = end.ToUniversalTime();
                     filterString = (filterString == null ? null : filterString + " and ") + columnname + " <= @" + parametersForLinqQuery.Count;
                     parametersForLinqQuery.Add(end);
                 }
@@ -161,12 +163,14 @@ namespace Mvc.JQuery.DataTables
                 DateTime start, end;
                 if (DateTime.TryParse(parts[0] ?? "", out start))
                 {
+                    start = start.ToUniversalTime();
                     filterString = columnname + " >= @" + parametersForLinqQuery.Count;
                     parametersForLinqQuery.Add(start);
                 }
 
                 if (DateTime.TryParse(parts[1] ?? "", out end))
                 {
+                    end = end.ToUniversalTime();
                     filterString = (filterString == null ? null : filterString + " and ") + columnname + " <= @" + parametersForLinqQuery.Count;
                     parametersForLinqQuery.Add(end);
                 }


### PR DESCRIPTION
All dates in the datetime filter were converted to UTC prior to selecting them from the database. Range filters were not considered however, leading to missing entries.