### PR TITLE
Fix for an issue with data table filtering and allowing for user defined filters

### DIFF
--- a/Mvc.JQuery.DataTables.Common/DataTablesFiltering.cs
+++ b/Mvc.JQuery.DataTables.Common/DataTablesFiltering.cs
@@ -30,7 +30,11 @@ namespace Mvc.JQuery.DataTables
                     }
                 }
                 var values = parts.Where(p => p != null);
-                data = data.Where(string.Join(" or ", values), parameters.ToArray());
+                var filterClause = string.Join(" or ", values);
+                if (string.IsNullOrWhiteSpace(filterClause) == false)
+                {
+                    data = data.Where(filterClause, parameters.ToArray());
+                }
             }
             for (int i = 0; i < dtParameters.sSearchValues.Count; i++)
             {

--- a/Mvc.JQuery.DataTables.Common/DataTablesFiltering.cs
+++ b/Mvc.JQuery.DataTables.Common/DataTablesFiltering.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace Mvc.JQuery.DataTables
 {
-    internal class DataTablesFiltering
+    public class DataTablesFiltering
     {
         public IQueryable<T> ApplyFiltersAndSort<T>(DataTablesParam dtParameters, IQueryable<T> data, DataTablesPropertyInfo[] columns)
         {
@@ -118,7 +118,7 @@ namespace Mvc.JQuery.DataTables
 
         public static void RegisterFilter<T>(GuardedFilter filter)
         {
-            Filters.Add(Guard(arg => arg is T, filter));
+            Filters.Add(Guard(arg => arg.Type == typeof(T), filter));
         }
 
         private static string GetFilterClause(string query, DataTablesPropertyInfo column, List<object> parametersForLinqQuery)

--- a/Mvc.JQuery.DataTables.Common/Processing/TypeFilters.cs
+++ b/Mvc.JQuery.DataTables.Common/Processing/TypeFilters.cs
@@ -251,11 +251,17 @@ namespace Mvc.JQuery.DataTables
 
         public static string EnumFilter(string q, string columnname, DataTablesPropertyInfo propertyInfo, List<object> parametersForLinqQuery)
         {
-
-            if (q.StartsWith("^")) q = q.Substring(1);
-            if (q.EndsWith("$")) q = q.Substring(0, q.Length - 1);
-            parametersForLinqQuery.Add(ParseValue(q, propertyInfo.Type));
-            return columnname + " == @" + (parametersForLinqQuery.Count - 1);
+            try
+            {
+                if (q.StartsWith("^")) q = q.Substring(1);
+                if (q.EndsWith("$")) q = q.Substring(0, q.Length - 1);
+                parametersForLinqQuery.Add(ParseValue(q, propertyInfo.Type));
+                return columnname + " == @" + (parametersForLinqQuery.Count - 1);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed an issue when filtering on a data table throws an exception in cases there are no relevant columns to be filtered. Example: data table contains only numerical columns and a user types 'a letter'. Since the letter cannot be converted to a number, no where clause is generated and data.Where command was failing.