### PR TITLE
Assume end of day on daterange filter when no time was passed

### DIFF
--- a/Mvc.JQuery.DataTables.Common/Processing/TypeFilters.cs
+++ b/Mvc.JQuery.DataTables.Common/Processing/TypeFilters.cs
@@ -170,6 +170,10 @@ namespace Mvc.JQuery.DataTables
 
                 if (DateTime.TryParse(parts[1] ?? "", out end))
                 {
+                    if (end == end.Date) {
+                      end = end.AddHours(23).AddMinutes(59).AddSeconds(59);
+                    }
+
                     end = end.ToUniversalTime();
                     filterString = (filterString == null ? null : filterString + " and ") + columnname + " <= @" + parametersForLinqQuery.Count;
                     parametersForLinqQuery.Add(end);


### PR DESCRIPTION
Filtering a date range with start and end being the same date (without time) will result in no results being found since the dates are identical (e.g. 2020-03-26~2020-03-26).

This PR takes the end of day for the end date if only the date was passed to allow for same-day filtering.

Potentially this is a breaking change if users now rely on no results being returned