### PR TITLE
use dtParameters.sColumnNames when searching

### DIFF
--- a/Mvc.JQuery.DataTables.Common/DataTablesFiltering.cs
+++ b/Mvc.JQuery.DataTables.Common/DataTablesFiltering.cs
@@ -21,7 +21,19 @@ namespace Mvc.JQuery.DataTables
                     {
                         try
                         {
-                            parts.Add(GetFilterClause(dtParameters.sSearch, columns[i], parameters));
+                            if(dtParameters.sColumnNames.Count> 0)
+                            {
+                                var col = columns.FirstOrDefault(c => String.Compare(c.PropertyInfo.Name.ToLower(), dtParameters.sColumnNames[i].ToLower()) == 0);
+                                if (col != null)
+                                { parts.Add(GetFilterClause(dtParameters.sSearch, col, parameters)); }
+
+                            }
+                            else
+                            {
+                                parts.Add(GetFilterClause(dtParameters.sSearch, columns[i], parameters));
+                            }
+
+
                         }
                         catch (Exception)
                         {


### PR DESCRIPTION
I noticed that even if I'm using ArrayOutputType.ArrayOfObjects when returning data to datatable, when searching the code ignores the "object-like" behaviour and uses the old-style index based logics.
To obtain the same behaviour of ArrayOutputType.ArrayOfObjects also in searching feature, I think that accessing columns by looking at the PropertyInfoNames is more consistent and doesn't push you to maintain a specific column order, exactly like you expect when you want to manage data in ArrayOutputType.ArrayOfObjects mode.

Hope this could help